### PR TITLE
Pass blob config through runtime config

### DIFF
--- a/apps/orchestrator/lib/blobStorage.ts
+++ b/apps/orchestrator/lib/blobStorage.ts
@@ -1,5 +1,7 @@
 import { createUploadTarget, type BlobObjectKind, type UploadTarget } from '@quizdude/shared';
 
+import { getRuntimeConfig } from './config/env';
+
 interface GenerateLectureUploadInput {
   lectureId: string;
   objects: Array<{
@@ -13,6 +15,10 @@ export async function generateLectureUploadTargets(
   input: GenerateLectureUploadInput,
 ): Promise<UploadTarget[]> {
   const { lectureId, objects } = input;
+  const {
+    blob: { readWriteToken, publicBaseUrl },
+  } = getRuntimeConfig();
+
   const targets = await Promise.all(
     objects.map((object) =>
       createUploadTarget({
@@ -20,6 +26,8 @@ export async function generateLectureUploadTargets(
         objectKey: object.filename,
         contentType: object.contentType,
         kind: object.kind,
+        readWriteToken,
+        publicBaseUrl,
       }),
     ),
   );

--- a/apps/orchestrator/lib/config/env.ts
+++ b/apps/orchestrator/lib/config/env.ts
@@ -2,7 +2,10 @@ import { z } from 'zod';
 
 const envSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL 환경 변수가 필요합니다.'),
-  BLOB_READ_WRITE_TOKEN: z.string().min(1, 'BLOB_READ_WRITE_TOKEN 환경 변수가 필요합니다.'),
+  BLOB_READ_WRITE_TOKEN: z
+    .string()
+    .optional()
+    .transform((value) => (value ? value.trim() : undefined)),
   BLOB_PUBLIC_BASE_URL: z
     .string()
     .url('BLOB_PUBLIC_BASE_URL 은 URL 형식이어야 합니다.')
@@ -25,7 +28,7 @@ const envSchema = z.object({
 export interface RuntimeConfig {
   databaseUrl: string;
   blob: {
-    readWriteToken: string;
+    readWriteToken?: string;
     publicBaseUrl?: string;
   };
   features: {

--- a/apps/orchestrator/lib/services/__tests__/lectureService.test.ts
+++ b/apps/orchestrator/lib/services/__tests__/lectureService.test.ts
@@ -110,6 +110,8 @@ describe('lectureService', () => {
           filename: 'file.pdf',
         },
       ],
+      readWriteToken: 'token',
+      publicBaseUrl: 'https://blob.example.com',
     });
     expect(prismaTransaction).toHaveBeenCalled();
     expect(result).toMatchObject({


### PR DESCRIPTION
## Summary
- allow the orchestrator blob helper to read runtime-provided Blob tokens instead of reaching into process.env directly
- propagate the runtime token/base URL when generating lecture upload targets so missing Blob config surfaces as a structured error
- update orchestrator lecture service tests to expect the forwarded Blob settings

## Testing
- pnpm --filter orchestrator test *(fails: @quizdude/db workspace package has no built entry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e608435470832b96eafdc6dfb843e1