### PR TITLE
Fix Gemini payload to include structured output config in generationConfig

### DIFF
--- a/packages/shared/src/gemini/client.ts
+++ b/packages/shared/src/gemini/client.ts
@@ -124,15 +124,17 @@ export class GeminiClient {
     await this.ensureModelAvailable(model);
 
     const url = `${this.apiBaseUrl}/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${this.apiKey}`;
-    const payload: Record<string, unknown> = {
-      contents: options.contents,
+    const generationConfig: Record<string, unknown> = {
+      temperature: options.temperature ?? 0.2,
+      topK: options.topK ?? 32,
+      topP: options.topP ?? 0.95,
       responseMimeType: options.responseMimeType ?? 'application/json',
       responseSchema: options.responseSchema as JsonSchema,
-      generationConfig: {
-        temperature: options.temperature ?? 0.2,
-        topK: options.topK ?? 32,
-        topP: options.topP ?? 0.95,
-      },
+    };
+
+    const payload: Record<string, unknown> = {
+      contents: options.contents,
+      generationConfig,
     };
 
     if (options.systemInstruction) {


### PR DESCRIPTION
## Summary
- move the structured output fields into generationConfig when calling Gemini
- keep default JSON mime type while preserving temperature and sampling options

## Testing
- pnpm test *(fails: orchestrator tests cannot resolve @quizdude/db package entry, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e61d62b6fc832ba7d57fb51e9aacdd