### PR TITLE
fix: align quiz answer schema with gemini requirements

### DIFF
--- a/packages/shared/src/schemas/jsonSchemas.ts
+++ b/packages/shared/src/schemas/jsonSchemas.ts
@@ -132,7 +132,8 @@ export const quizSetJsonSchema: JsonSchema = {
           },
           answer: {
             type: 'integer',
-            enum: [0, 1, 2, 3],
+            minimum: 0,
+            maximum: 3,
           },
           rationale: { type: 'string' },
           difficulty: {


### PR DESCRIPTION
## Summary
- replace the numeric enum in the quiz answer schema with minimum/maximum bounds so Gemini accepts the response schema

## Testing
- pnpm --filter @quizdude/shared test

------
https://chatgpt.com/codex/tasks/task_e_68e62b76c164832b8d64697be3de2397